### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "c"
+run = ""

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 </hr>
 
 <h3><i>README.md coming soon<i></h3>
+
+[![Run on Repl.it](https://repl.it/badge/github/ARACADERISE/Database-Node)](https://repl.it/github/ARACADERISE/Database-Node)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).